### PR TITLE
fix: adjust kube-rbac-proxy image from gcr.io to docker.io

### DIFF
--- a/bundle/manifests/spark-k8s-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/spark-k8s-operator.clusterserviceversion.yaml
@@ -66,10 +66,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-10-11T16:01:05Z"
+    createdAt: "2023-10-23T07:59:35Z"
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4-alpha
-  name: spark-k8s-operator.v0.0.2
+  name: spark-k8s-operator.v0.0.1-alpha
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -240,7 +240,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+                image: docker.io/bitnami/kube-rbac-proxy:0.13.1
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -264,7 +264,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/zncdata/spark-k8s-operator:0.0.2
+                image: quay.io/zncdata/spark-k8s-operator:0.0.1-alpha
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -350,4 +350,4 @@ spec:
   maturity: alpha
   provider:
     name: zncdata-labs
-  version: 0.0.2
+  version: 0.0.1-alpha

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: docker.io/bitnami/kube-rbac-proxy:0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/zncdata/spark-k8s-operator
-  newTag: 0.0.2
+  newTag: 0.0.1-alpha


### PR DESCRIPTION
fix: adjust kube-rbac-proxy image from gcr.io to docker.io